### PR TITLE
Add libraries to connect benchmarks with profiler

### DIFF
--- a/enclaves/libjpeg/Enclave/encl.config.xml
+++ b/enclaves/libjpeg/Enclave/encl.config.xml
@@ -4,7 +4,7 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0x1000000</HeapMaxSize>
-  <EnableAEXNotify>1</EnableAEXNotify>
+  <EnableAEXNotify>0</EnableAEXNotify>
   <TCSNum>1</TCSNum>
   <TCSPolicy>1</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/meson.build
+++ b/meson.build
@@ -217,6 +217,7 @@ sgx_step = static_library('sgx-step',
   './sgx-step/libsgxstep/pt.c',
   './sgx-step/libsgxstep/sched.c',
   './sgx-step/libsgxstep/spy.c',
+  './sgx-step/libsgxstep/simstep.c',
   c_args : c_args,
   pic : true,
 )
@@ -224,3 +225,4 @@ sgx_step = static_library('sgx-step',
 subdir('runtime')
 subdir('enclaves')
 subdir('benchmark')
+subdir('profiler')

--- a/profiler/argon2.c
+++ b/profiler/argon2.c
@@ -1,0 +1,11 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+}
+
+void profiler_run(int eid) {
+}

--- a/profiler/libgcrypt.c
+++ b/profiler/libgcrypt.c
@@ -1,0 +1,11 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+}
+
+void profiler_run(int eid) {
+}

--- a/profiler/libjpeg.c
+++ b/profiler/libjpeg.c
@@ -1,0 +1,81 @@
+#include <sgx_urts.h>
+#include "encl_u.h"
+#include "libsgxstep/pf.h"
+#include <sys/mman.h>
+#include <signal.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include "libsgxstep/debug.h"
+#include "libsgxstep/file.h"
+#include "libsgxstep/simstep.h"
+
+void ocall_idct_islow(void)
+{
+    printf("hack: explicit leakage\n");
+}
+
+void ocall_all_zero(void)
+{
+    printf("hack: explicit leakage\n");
+}
+
+int load_image(sgx_enclave_id_t eid, char *image_path, size_t buffer_size,
+               size_t max_size) {
+  printf("input size: %d, output_size: %d\n", buffer_size, max_size);
+  uint8_t *in_buffer = malloc(buffer_size);
+  ASSERT(in_buffer);
+  size_t in_sz = file_read(image_path, in_buffer, buffer_size);
+  info("read image from file");
+  int load_res;
+  sgx_status_t res =
+      enclave_jpeg_load_image(eid, &load_res, in_buffer, in_sz, max_size);
+  if (res != SGX_SUCCESS)
+    return res;
+  info("loaded image into enclave");
+  free(in_buffer);
+  info("free returned");
+  return load_res;
+}
+
+int decompress_image(sgx_enclave_id_t eid) {
+  info("decompressing image");
+  size_t out_size;
+  sgx_status_t res = enclave_jpeg_decompress_loaded(eid, &out_size);
+  info("decompressing done");
+  if (out_size == -1)
+    return SGX_ERROR_UNEXPECTED;
+  if (res != SGX_SUCCESS)
+    return res;
+  info("decompressing ok");
+  return 0;
+}
+
+int free_image(sgx_enclave_id_t eid) {
+  info("freeing image");
+  sgx_status_t res = enclave_jpeg_free_image(eid);
+  if (res != SGX_SUCCESS)
+    return res;
+  return 0;
+}
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc,
+                    char **argv) {
+  if (argc != 3)
+    exit(1);
+  char *image_path = argv[0];
+  size_t buffer_size = atoi(argv[1]);
+  size_t max_size = atoi(argv[2]);
+
+  SGX_ASSERT(load_image(eid, image_path, buffer_size, max_size));
+}
+
+void profiler_run(int eid) {
+  info_event("calling enclave jpeg decompression..");
+  start_single_stepping();
+  SGX_ASSERT(decompress_image(eid));
+  stop_single_stepping();
+}
+
+void profiler_destroy(int eid) {
+  SGX_ASSERT(free_image(eid));
+}

--- a/profiler/meson.build
+++ b/profiler/meson.build
@@ -1,0 +1,20 @@
+profiler_common = static_library('profiler_common',
+  dependencies : [sgx_urts, sgx_uae_service],
+  link_with : [test_common, sgx_step], 
+  include_directories : ['../enclaves/common', '../sgx-step'],
+  install : true,
+  c_args : c_args,
+)
+
+foreach e : built_enclaves
+  shared_library('prof-' + e['name'], 
+    e['name'] + '.c',
+    e['untrusted_edl'],
+    link_with : [e['untrusted_lib'], profiler_common], 
+    link_whole : [test_common],
+    dependencies : [sgx_urts, sgx_uae_service, sgx_usgxssl],
+    include_directories : ['../enclaves/common', '../sgx-step'],
+    install : true,
+    c_args : c_args,
+  )
+endforeach

--- a/profiler/micro.c
+++ b/profiler/micro.c
@@ -1,0 +1,12 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+#include <stdio.h>
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc,
+                    char **argv) {}
+
+void profiler_run(int eid) {
+}

--- a/profiler/openssl.c
+++ b/profiler/openssl.c
@@ -1,0 +1,23 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+}
+
+void profiler_run(int eid) {
+  // SGX_ASSERT(ecall_test(eid));
+  int ret;
+  uint64_t res[10];
+  uint64_t data[10];
+  uint64_t code[10];
+  // SGX_ASSERT(ecall_select_benchmark(eid, 0));
+  // SGX_ASSERT(ecall_run_benchmark(eid, &ret, 10, 10, res, data, code));
+  // ASSERT(ret == 0);
+  SGX_ASSERT(ecall_select_benchmark(eid, 1));
+  start_single_stepping();
+  SGX_ASSERT(ecall_run_benchmark(eid, &ret, 10, 10, res, data, code));
+  stop_single_stepping();
+}

--- a/profiler/profiler.h
+++ b/profiler/profiler.h
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+extern char *ENCLAVE_SO;
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc,
+                    char **argv);
+void profiler_run(int eid);
+void profiler_destroy(int eid);

--- a/profiler/rsa.c
+++ b/profiler/rsa.c
@@ -1,0 +1,38 @@
+#include "encl_u.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+#include "pf.h"
+#include "profiler.h"
+
+int exponent_d, cipher, plain;
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc,
+                    char **argv) {
+  if (argc < 1) {
+    info("Invalid arguments for enclave call");
+    abort();
+  }
+  exponent_d = atoi(argv[0]);
+  void *sq_pt = NULL, *mul_pt = NULL, *modpow_pt = NULL, *stack_pt = NULL;
+  SGX_ASSERT(ecall_get_square_adrs(eid, &sq_pt));
+  SGX_ASSERT(ecall_get_multiply_adrs(eid, &mul_pt));
+  SGX_ASSERT(ecall_get_modpow_adrs(eid, &modpow_pt));
+  SGX_ASSERT(ecall_get_stack_adrs(eid, &stack_pt));
+  modpow_pt = (void *)(((uint64_t)modpow_pt) & ~0xfff);
+  info("stack somewhere around %p", stack_pt);
+  info("square at %p; muliply at %p; modpow at %p", sq_pt, mul_pt, modpow_pt);
+
+  SGX_ASSERT(ecall_rsa_set_d(eid, exponent_d));
+  info("Secret value: %d", exponent_d);
+  SGX_ASSERT(ecall_rsa_encode(eid, &cipher, 1234));
+
+  info("RSA encode done: %d", cipher);
+}
+
+void profiler_run(int eid) {
+  start_single_stepping();
+  SGX_ASSERT(ecall_rsa_decode(eid, &plain, cipher));
+  stop_single_stepping();
+
+  info("RSA decode done: %d", plain);
+}

--- a/profiler/simple.c
+++ b/profiler/simple.c
@@ -1,0 +1,11 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+}
+
+void profiler_run(int eid) {
+}

--- a/profiler/wolfssl.c
+++ b/profiler/wolfssl.c
@@ -1,0 +1,11 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+}
+
+void profiler_run(int eid) {
+}

--- a/profiler/yescrypt.c
+++ b/profiler/yescrypt.c
@@ -1,0 +1,20 @@
+#include "profiler.h"
+#include "encl_u.h"
+#include "pf.h"
+#include "libsgxstep/debug.h"
+#include "libsgxstep/simstep.h"
+
+void profiler_setup(int eid, int e_size, void *e_start, uint64_t argc, char **argv) {
+  sgx_status_t res = ecall_select_benchmark(eid, atoi(argv[0]));
+}
+
+void profiler_run(int eid) {
+  int ret;
+  uint64_t result;
+  uint64_t code;
+  uint64_t data;
+  start_single_stepping();
+  ecall_run_benchmark(eid, &ret, 0, 1, &result, &data, &code);
+  stop_single_stepping();
+  printf("Done: %d (cycles = %d, code = %d, data = %d)", ret, result, code, data);
+}


### PR DESCRIPTION
These libraries are used to allow the profiler to interact with the enclaves. They were previously removed when the profiler was moved to the SGX-Step repo, but are now added again to enable profiling of instrumented binaries, which is needed for the TLBlur simulation.

The profiler interface is also refactored to be more consistent with the benchmark interface.